### PR TITLE
Remove Rails/TargetRailsVersion

### DIFF
--- a/config/rubocop-rails.yml
+++ b/config/rubocop-rails.yml
@@ -7,9 +7,6 @@ AllCops:
     - db/schema.rb
     - vendor/bundle/**/*
 
-Rails:
-  TargetRailsVersion: ">= 6.0"
-
 Rails/ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'
   Enabled: false


### PR DESCRIPTION
fixes Warning: Rails does not support TargetRailsVersion parameter. it looks like this is now a mixin for other cops rather than being a standalone cop.