### PR TITLE
Update list of allowed prefixes for RSpec context definition

### DIFF
--- a/config/rubocop-rspec.yml
+++ b/config/rubocop-rspec.yml
@@ -1,6 +1,17 @@
 # RuboCop RSpec extension configuration overrides
 # https://github.com/rubocop/rubocop-rspec
 
+RSpec/ContextWording:
+  Description: >-
+    Checks that context docstring starts with an allowed prefix.
+  Prefixes:
+    - after
+    - as
+    - "on"
+    - when
+    - with
+    - without
+
 RSpec/ExampleLength:
   Exclude:
     - spec/features/**/*


### PR DESCRIPTION
Adds additional context definitions which are in use across other projects.

From the Rubocop docs:
> The default list of prefixes is minimal. Users are encouraged to tailor the configuration to meet project needs. Other acceptable prefixes may include if, unless, for, before, after, or during. They may consist of multiple words if desired.

The updated list is based on our experiences writing comprehensive tests for several applications.