### PR TITLE
Allow repeated examples in policy specs

### DIFF
--- a/config/rubocop-rspec.yml
+++ b/config/rubocop-rspec.yml
@@ -21,3 +21,7 @@ RSpec/MultipleExpectations:
   Exclude:
     - spec/features/**/*
     - spec/system/**/*
+
+RSpec/RepeatedExample:
+  Exclude:
+    - spec/policies/**/*


### PR DESCRIPTION
Permission checks are usually grouped by permission rather than by expectation, which frequently leads to examples being repeated. However, repeated examples here allows for more readable specs, rather than a dogmatic approach to DRY.